### PR TITLE
Allow command piping to work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+scratch/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/src/annmas/__main__.py
+++ b/src/annmas/__main__.py
@@ -6,7 +6,9 @@ import click_log
 import sys
 
 from .inspect import command as inspect
+
 # porcelain
+
 from .segment import command as segment
 from .annotate import command as annotate
 from .train import command as train
@@ -14,23 +16,23 @@ from .train import command as train
 from .meta import VERSION
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("version")
 click_log.basic_config(logger)
 logger.handlers[0].formatter = logging.Formatter(
-    "[%(levelname)s %(asctime)s] %(message)s", "%Y-%m-%d %H:%M:%S"
+    "[%(levelname)s %(asctime)s %(name)s] %(message)s", "%Y-%m-%d %H:%M:%S"
 )
 
 
 @click.group(name="annmas")
 def main_entry():
-    logger.info("annmas invoked via: %s", " ".join(sys.argv))
+    logger.info("Invoked via: annmas %s", " ".join(sys.argv))
 
 
 @main_entry.command()
 @click_log.simple_verbosity_option(logger)
 def version():
-    """Print the version of annmas"""
-    logger.info(f"annmas: {VERSION}")
+    """Print the version of annmas."""
+    click.echo(VERSION)
 
 
 # Update with new sub-commands:

--- a/src/annmas/annotate/command.py
+++ b/src/annmas/annotate/command.py
@@ -4,6 +4,7 @@ import itertools
 import re
 import time
 import collections
+import os
 
 from inspect import getframeinfo, currentframe, getdoc
 
@@ -28,10 +29,9 @@ __SENTINEL_VALUE = r"THE _MOST_ CROMULENT SENTINEL VALUE."
 SEGMENTS_TAG = "SG"
 SEGMENTS_RC_TAG = "RC"
 
-logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr)
+logger = logging.getLogger("annotate")
 click_log.basic_config(logger)
-
-mod_name = "annotate"
 
 
 # Named tuple to store alignment information:
@@ -54,7 +54,7 @@ class SegmentInfo(collections.namedtuple("SegmentInfo", ["name", "start", "end"]
         return SegmentInfo(match[1], int(match[2]), int(match[3]))
 
 
-@click.command(name=mod_name)
+@click.command(name=logger.name)
 @click_log.simple_verbosity_option(logger)
 @click.option(
     "-m",
@@ -67,23 +67,24 @@ class SegmentInfo(collections.namedtuple("SegmentInfo", ["name", "start", "end"]
     "-t",
     "--threads",
     type=int,
-    default=mp.cpu_count() - 1,
+    default=1,
     show_default=True,
     help="number of threads to use (0 for all)",
 )
 @click.option(
     "-o",
     "--output-bam",
-    required=True,
+    default="-",
     type=click.Path(exists=False),
-    help="segment-annotated bam output",
+    help="annotated bam output  [default: stdout]",
 )
 @click.argument("input-bam", type=click.Path(exists=True))
 def main(model, threads, output_bam, input_bam):
     """Annotate reads in a BAM file with segments from the model."""
 
     t_start = time.time()
-    logger.info(f"annmas: {mod_name} started")
+
+    logger.info("Invoked via: annmas %s", " ".join(sys.argv[1:]))
 
     threads = mp.cpu_count() if threads <= 0 or threads > mp.cpu_count() else threads
     logger.info(f"Running with {threads} worker subprocess(es)")
@@ -96,7 +97,7 @@ def main(model, threads, output_bam, input_bam):
         logger.info("Using default annotation model")
 
     # Create queues for data:
-    queue_size = threads*2 if threads < 10 else 20
+    queue_size = threads * 2 if threads < 10 else 20
     manager = mp.Manager()
     input_data_queue = manager.Queue(maxsize=queue_size)
     results = manager.Queue()
@@ -109,14 +110,23 @@ def main(model, threads, output_bam, input_bam):
     # input_data_queue = ManyProducerSingleConsumerIpcQueue()
 
     for i in range(threads):
-        p = mp.Process(target=_worker_segmentation_fn, args=(input_data_queue, results, i, m))
+        p = mp.Process(
+            target=_worker_segmentation_fn, args=(input_data_queue, results, i, m)
+        )
         p.start()
         worker_pool.append(p)
 
     pysam.set_verbosity(0)  # silence message about the .bai file not being found
     with pysam.AlignmentFile(
         input_bam, "rb", check_sq=False, require_index=False
-    ) as bam_file, tqdm.tqdm(desc="Progress", unit=" read", colour="green", file=sys.stdout) as pbar:
+    ) as bam_file, tqdm.tqdm(
+        desc="Progress",
+        unit=" read",
+        colour="green",
+        file=sys.stderr,
+        leave=False,
+        disable=input_bam == "-",
+    ) as pbar:
 
         # Get our header from the input bam file:
         out_bam_header_dict = bam_file.header.to_dict()
@@ -137,7 +147,10 @@ def main(model, threads, output_bam, input_bam):
         out_header = pysam.AlignmentHeader.from_dict(out_bam_header_dict)
 
         # Start output worker:
-        output_worker = mp.Process(target=_write_thread_fn, args=(results, out_header, output_bam, pbar))
+        res = manager.dict({"num_reads_annotated": 0, "num_sections": 0})
+        output_worker = mp.Process(
+            target=_write_thread_fn, args=(results, out_header, output_bam, pbar, res)
+        )
         output_worker.start()
 
         # Add in a `None` sentinel value at the end of the queue - one for each subprocess - so we guarantee
@@ -149,8 +162,8 @@ def main(model, threads, output_bam, input_bam):
                 r = r.to_string()
             input_data_queue.put(r)
 
-        logger.info("Finished reading data and sending it to sub-processes.")
-        logger.info("Waiting for sub-processes to finish...")
+        logger.debug("Finished reading data and sending it to sub-processes.")
+        logger.debug("Waiting for sub-processes to finish...")
 
         # Wait for our input jobs to finish:
         for p in worker_pool:
@@ -164,18 +177,17 @@ def main(model, threads, output_bam, input_bam):
         results.put(__SENTINEL_VALUE)
         output_worker.join()
 
-    logger.info(f"annmas: {mod_name} finished.")
-    logger.info(f"annmas: elapsed time: %2.5fs.", time.time() - t_start)
+    logger.info(
+        f"Annotated {res['num_reads_annotated']} reads with {res['num_sections']} total sections."
+    )
+    logger.info(f"Done. Elapsed time: %2.2fs.", time.time() - t_start)
 
 
-def _write_thread_fn(out_queue, out_bam_header, out_bam_file_name, pbar):
+def _write_thread_fn(out_queue, out_bam_header, out_bam_file_name, pbar, res):
     """Thread / process fn to write out all our data."""
 
-    num_reads_annotated = 0
-    num_sections = 0
-
     with pysam.AlignmentFile(
-            out_bam_file_name, "wb", header=out_bam_header
+        out_bam_file_name, "wb", header=out_bam_header
     ) as out_bam_file:
 
         while True:
@@ -219,14 +231,10 @@ def _write_thread_fn(out_queue, out_bam_header, out_bam_file_name, pbar):
             out_bam_file.write(read)
 
             # Increment our counters:
-            num_reads_annotated += 1
-            num_sections += len(segments)
+            res["num_reads_annotated"] += 1
+            res["num_sections"] += len(segments)
 
             pbar.update(1)
-
-    logger.info(
-        f"annmas {mod_name}: annotated {num_reads_annotated} reads with {num_sections} total sections."
-    )
 
 
 def _worker_segmentation_fn(in_queue, out_queue, worker_num, model):
@@ -251,7 +259,9 @@ def _worker_segmentation_fn(in_queue, out_queue, worker_num, model):
 
         # Unpack our data here:
         read = raw_data
-        read = pysam.AlignedSegment.fromstring(read, pysam.AlignmentHeader.from_dict(dict()))
+        read = pysam.AlignedSegment.fromstring(
+            read, pysam.AlignmentHeader.from_dict(dict())
+        )
 
         # Process and place our data on the output queue:
         segment_info = _segment_read(read, model)
@@ -259,7 +269,7 @@ def _worker_segmentation_fn(in_queue, out_queue, worker_num, model):
         out_queue.put(segment_info)
         num_reads_segmented += 1
 
-    logger.info(f"Worker %d: Num reads segmented: %d", worker_num, num_reads_segmented)
+    logger.debug(f"Worker %d: Num reads segmented: %d", worker_num, num_reads_segmented)
 
 
 def _reverse_segments(segments, read_length):
@@ -268,7 +278,9 @@ def _reverse_segments(segments, read_length):
     for seg in segments[::-1]:
         rc_segments.append(
             # Subtract 2 to account for inclusive coordinates on both ends:
-            SegmentInfo(seg.name, read_length - seg.end - 2, read_length - seg.start - 2)
+            SegmentInfo(
+                seg.name, read_length - seg.end - 2, read_length - seg.start - 2
+            )
         )
 
     return rc_segments

--- a/src/annmas/annotate/command.py
+++ b/src/annmas/annotate/command.py
@@ -67,7 +67,7 @@ class SegmentInfo(collections.namedtuple("SegmentInfo", ["name", "start", "end"]
     "-t",
     "--threads",
     type=int,
-    default=1,
+    default=mp.cpu_count() - 1,
     show_default=True,
     help="number of threads to use (0 for all)",
 )

--- a/src/annmas/inspect/command.py
+++ b/src/annmas/inspect/command.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import click
 import click_log
@@ -9,23 +10,58 @@ from construct import *
 
 from ..utils.model import *
 
-logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr)
+logger = logging.getLogger("inspect")
 click_log.basic_config(logger)
 
 
-@click.command(name="inspect")
+@click.command(name=logger.name)
 @click_log.simple_verbosity_option(logger)
-@click.option("-r", "--read-names", type=str, multiple=True, help="read names (or file(s) of read names) to inspect")
-@click.option("-m", "--model", required=False, type=click.Path(exists=True), help="pre-trained model to apply")
-@click.option("-p", "--pbi", required=False, type=click.Path(exists=True), help="BAM .pbi index file")
-@click.option("-f", "--file-format", default="png", type=click.Choice(['png', 'pdf']), help="Image file format")
-@click.option("-o", "--outdir", default=".", required=False, type=click.Path(exists=False), help="Output directory")
-@click.argument('input-bam', type=click.Path(exists=True))
+@click.option(
+    "-r",
+    "--read-names",
+    type=str,
+    multiple=True,
+    help="read names (or file(s) of read names) to inspect",
+)
+@click.option(
+    "-m",
+    "--model",
+    required=False,
+    type=click.Path(exists=True),
+    help="pre-trained model to apply",
+)
+@click.option(
+    "-p",
+    "--pbi",
+    required=False,
+    type=click.Path(exists=True),
+    help="BAM .pbi index file",
+)
+@click.option(
+    "-f",
+    "--file-format",
+    default="png",
+    type=click.Choice(["png", "pdf"]),
+    help="Image file format",
+)
+@click.option(
+    "-o",
+    "--outdir",
+    default=".",
+    required=False,
+    type=click.Path(exists=False),
+    help="Output directory",
+)
+@click.argument("input-bam", type=click.Path(exists=True))
 def main(read_names, model, pbi, file_format, outdir, input_bam):
-    """Inspect the classification results on specified reads"""
-    logger.info(f"annmas: inspect started")
+    """Inspect the classification results on specified reads."""
 
-    pbi = f'{input_bam}.pbi' if pbi is None else pbi
+    t_start = time.time()
+
+    logger.info("Invoked via: annmas %s", " ".join(sys.argv[1:]))
+
+    pbi = f"{input_bam}.pbi" if pbi is None else pbi
     if not os.path.exists(pbi):
         raise FileNotFoundError(f"Missing .pbi file for {input_bam}")
 
@@ -42,21 +78,21 @@ def main(read_names, model, pbi, file_format, outdir, input_bam):
     file_offsets = load_read_offsets(pbi, load_read_names(read_names))
 
     pysam.set_verbosity(0)
-    bf = pysam.Samfile(input_bam, 'rb', check_sq=False, require_index=False)
+    bf = pysam.Samfile(input_bam, "rb", check_sq=False, require_index=False)
 
     for z in file_offsets:
-        bf.seek(file_offsets[z]['offset'])
+        bf.seek(file_offsets[z]["offset"])
         read = bf.__next__()
 
         out = f'{outdir}/{re.sub("/", "_", read.query_name)}.{file_format}'
         seq, path, logp = annotate_read(read, m)
 
         logger.info("Drawing read '%s' to '%s'", read.query_name, out)
-        draw_state_sequence(seq, path, read, out, size=13, family='monospace')
+        draw_state_sequence(seq, path, read, out, size=13, family="monospace")
 
     bf.close()
 
-    logger.info("annmas: inspect finished")
+    logger.info(f"Done. Elapsed time: %2.2fs.", time.time() - t_start)
 
 
 def load_read_names(read_names):
@@ -64,7 +100,7 @@ def load_read_names(read_names):
 
     for r in read_names:
         if os.path.exists(r):
-            with open(r, 'r') as f:
+            with open(r, "r") as f:
                 for line in f:
                     # Space / Tab / Newline / Line feed are all forbidden in read names by the sam spec, so we can
                     # trim it all off:
@@ -93,7 +129,6 @@ def load_read_offsets(pbi_file, read_names):
         "pbi_flags" / Int16ul,
         "n_reads" / Int32ul,
         "reserved" / Padding(18),
-
         # Basic information section (columnar format)
         "rgId" / Padding(this.n_reads * 4),
         "qStart" / Array(this.n_reads, Int32sl),
@@ -102,28 +137,28 @@ def load_read_offsets(pbi_file, read_names):
         "readQual" / Padding(this.n_reads * 4),
         "ctxtFlag" / Padding(this.n_reads * 1),
         "fileOffset" / Array(this.n_reads, Int64sl),
-        )
+    )
 
     # Make a list of bgzf virtual file offsets for sharding and store ZMW counts.
     file_offsets_hash = OrderedDict()
     for read_name in read_names:
         movie_name, zmw, r = re.split("/", read_name)
-        if r == 'ccs':
+        if r == "ccs":
             r = 0
         else:
             r = re.split("_", r)[0]
 
-        file_offsets_hash[f'{zmw}_{r}'] = {'read_name': read_name, 'offset': None}
+        file_offsets_hash[f"{zmw}_{r}"] = {"read_name": read_name, "offset": None}
 
     with gzip.open(pbi_file, "rb") as f:
         idx_contents = fmt.parse_stream(f)
 
         for j in range(0, idx_contents.n_reads):
-            key = f'{idx_contents.holeNumber[j]}_{idx_contents.qStart[j]}'
+            key = f"{idx_contents.holeNumber[j]}_{idx_contents.qStart[j]}"
 
             # Save virtual file offsets for the selected reads only
             if key in file_offsets_hash:
-                file_offsets_hash[key]['offset'] = idx_contents.fileOffset[j]
+                file_offsets_hash[key]["offset"] = idx_contents.fileOffset[j]
 
     return file_offsets_hash
 
@@ -164,7 +199,7 @@ def format_state_sequence(seq, path):
         "N": "#DF5A49",
         "O": "#DF5A49",
         "P": "#DF5A49",
-        "random": "#aaaaaa"
+        "random": "#aaaaaa",
     }
 
     labelled_bases = []
@@ -205,10 +240,10 @@ def draw_state_sequence(seq, path, read, out, **kwargs):
     t = ax.transData
     canvas = ax.figure.canvas
 
-    f.suptitle(f'{read.query_name} ({len(read.query_sequence)} bp)', fontsize=16)
+    f.suptitle(f"{read.query_name} ({len(read.query_sequence)} bp)", fontsize=16)
 
     f.patch.set_visible(False)
-    ax.axis('off')
+    ax.axis("off")
 
     columns = 150
     rows = 4 * 80
@@ -223,10 +258,17 @@ def draw_state_sequence(seq, path, read, out, **kwargs):
 
     for s, c, l in zip(strings, colors, labels):
         if column == 0:
-            ytic = ax.text(0, rows - row, f'{n}  ', transform=t, ha='right')
+            ytic = ax.text(0, rows - row, f"{n}  ", transform=t, ha="right")
 
-        text = ax.text(0, rows - row, s, color=c, transform=t, bbox=dict(facecolor=f'{c}22', edgecolor=f'{c}22', pad=0),
-                       **kwargs)
+        text = ax.text(
+            0,
+            rows - row,
+            s,
+            color=c,
+            transform=t,
+            bbox=dict(facecolor=f"{c}22", edgecolor=f"{c}22", pad=0),
+            **kwargs,
+        )
 
         # Write classified sequence
         text.draw(canvas.get_renderer())
@@ -235,12 +277,22 @@ def draw_state_sequence(seq, path, read, out, **kwargs):
         # I truly have no idea why I need the 0.72 scaling factor, but if I don't have this, PDF images
         # are super broken.
         scaling_factor = 1.00 if out.endswith(".png") else 0.72
-        t = transforms.offset_copy(text.get_transform(), x=scaling_factor*ex.width, units='dots')
+        t = transforms.offset_copy(
+            text.get_transform(), x=scaling_factor * ex.width, units="dots"
+        )
 
         # Write state label
         if l != "random":
-            ax.text(0 - (len(s) / 2), rows - row - 3.5, l, transform=t, va='bottom', ha='center', fontsize=8,
-                    bbox=dict(facecolor='white', edgecolor='black'))
+            ax.text(
+                0 - (len(s) / 2),
+                rows - row - 3.5,
+                l,
+                transform=t,
+                va="bottom",
+                ha="center",
+                fontsize=8,
+                bbox=dict(facecolor="white", edgecolor="black"),
+            )
 
         if l == "10x_Adapter":
             for o in range(10, 50, 10):
@@ -260,11 +312,12 @@ def draw_state_sequence(seq, path, read, out, **kwargs):
 
             text = ax.text(column, row, "")
             text.draw(canvas.get_renderer())
-            t = transforms.offset_copy(text.get_transform(), x=0, y=-30 * row, units='dots')
+            t = transforms.offset_copy(
+                text.get_transform(), x=0, y=-30 * row, units="dots"
+            )
 
-    y2tic = ax.text(0, rows - row, f'  {n}', transform=t, ha='left')
+    y2tic = ax.text(0, rows - row, f"  {n}", transform=t, ha="left")
 
-    plt.savefig(out, bbox_inches='tight')
+    plt.savefig(out, bbox_inches="tight")
 
     plt.close()
-

--- a/src/annmas/segment/command.py
+++ b/src/annmas/segment/command.py
@@ -32,7 +32,7 @@ click_log.basic_config(logger)
     "-t",
     "--threads",
     type=int,
-    default=1,
+    default=mp.cpu_count() - 1,
     show_default=True,
     help="number of threads to use (0 for all)",
 )

--- a/src/annmas/segment/command.py
+++ b/src/annmas/segment/command.py
@@ -21,28 +21,27 @@ from ..annotate.command import SEGMENTS_TAG
 from ..meta import VERSION
 
 
-logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr)
+logger = logging.getLogger("segment")
 click_log.basic_config(logger)
 
-mod_name = "segment"
 
-
-@click.command(name=mod_name)
+@click.command(name=logger.name)
 @click_log.simple_verbosity_option(logger)
 @click.option(
     "-t",
     "--threads",
     type=int,
-    default=mp.cpu_count() - 1,
+    default=1,
     show_default=True,
     help="number of threads to use (0 for all)",
 )
 @click.option(
     "-o",
     "--output-bam",
-    required=True,
+    default="-",
     type=click.Path(exists=False),
-    help="segment-annotated bam output",
+    help="segment-annotated bam output  [default: stdout]",
 )
 @click.option(
     "-s",
@@ -50,7 +49,7 @@ mod_name = "segment"
     required=False,
     is_flag=True,
     default=False,
-    help="Do splitting of reads based on splitter delimiters, rather than whole array structure."
+    help="Do splitting of reads based on splitter delimiters, rather than whole array structure. "
     "This splitting will cause delimiter sequences to be repeated in each read they bound.",
 )
 @click.option(
@@ -60,16 +59,18 @@ mod_name = "segment"
     is_flag=True,
     default=False,
     help="If True, will keep the delimiter sequences in the resulting reads.  Otherwise the delimiter sequence "
-         "information will be removed from the resulting reads (the annotations for the delimiters will be preserved).",
+    "information will be removed from the resulting reads (the annotations for the delimiters will be preserved).",
 )
-@click.argument("input-bam", type=click.Path(exists=True))
+@click.argument("input-bam", default="-", type=click.Path())
 def main(threads, output_bam, do_simple_splitting, keep_delimiters, input_bam):
     """Segment pre-annotated reads from an input BAM file."""
+
     t_start = time.time()
-    logger.info(f"annmas: {mod_name} started")
+
+    logger.info("Invoked via: annmas %s", " ".join(sys.argv[1:]))
 
     threads = mp.cpu_count() if threads <= 0 or threads > mp.cpu_count() else threads
-    logger.info(f"Running with {threads} process(es)")
+    logger.info(f"Running with {threads} worker subprocess(es)")
 
     if do_simple_splitting:
         logger.info("Using simple splitting mode.")
@@ -85,21 +86,30 @@ def main(threads, output_bam, do_simple_splitting, keep_delimiters, input_bam):
     # Start worker sub-processes:
     worker_process_pool = []
     for _ in range(threads):
-        p = mp.Process(target=_sub_process_work_fn, args=(process_input_data_queue, results))
+        p = mp.Process(
+            target=_sub_process_work_fn, args=(process_input_data_queue, results)
+        )
         p.start()
         worker_process_pool.append(p)
 
     pysam.set_verbosity(0)  # silence message about the .bai file not being found
     with pysam.AlignmentFile(
         input_bam, "rb", check_sq=False, require_index=False
-    ) as bam_file, tqdm.tqdm(desc="Progress", unit=" read", colour="green", file=sys.stdout) as pbar:
+    ) as bam_file, tqdm.tqdm(
+        desc="Progress",
+        unit=" read",
+        colour="green",
+        file=sys.stderr,
+        leave=False,
+        disable=input_bam == "-",
+    ) as pbar:
 
         # Get our header from the input bam file:
         out_bam_header_dict = bam_file.header.to_dict()
 
         # Add our program group to it:
         pg_dict = {
-            "ID": f"annmas-{mod_name}-{VERSION}",
+            "ID": f"annmas-{logger.name}-{VERSION}",
             "PN": "annmas",
             "VN": f"{VERSION}",
             # Use reflection to get the doc string for this main function for our header:
@@ -113,9 +123,18 @@ def main(threads, output_bam, do_simple_splitting, keep_delimiters, input_bam):
         out_header = pysam.AlignmentHeader.from_dict(out_bam_header_dict)
 
         # Start output worker:
+        res = manager.dict({"num_reads_segmented": 0, "num_segments": 0})
         output_worker = mp.Process(
             target=_sub_process_write_fn,
-            args=(results, out_header, output_bam, pbar, do_simple_splitting, keep_delimiters)
+            args=(
+                results,
+                out_header,
+                output_bam,
+                pbar,
+                do_simple_splitting,
+                keep_delimiters,
+                res,
+            ),
         )
         output_worker.start()
 
@@ -137,8 +156,10 @@ def main(threads, output_bam, do_simple_splitting, keep_delimiters, input_bam):
         results.put(None)
         output_worker.join()
 
-        logger.info(f"annmas: {mod_name} finished.")
-        logger.info(f"annmas: elapsed time: %2.5fs.", time.time() - t_start)
+    logger.info(
+        f"Segmented {res['num_reads_segmented']} reads with {res['num_segments']} total segments."
+    )
+    logger.info(f"Done. Elapsed time: %2.2fs.", time.time() - t_start)
 
 
 def _sub_process_work_fn(in_queue, out_queue):
@@ -156,17 +177,24 @@ def _sub_process_work_fn(in_queue, out_queue):
             return
 
         # Unpack our data here:
-        read = pysam.AlignedSegment.fromstring(raw_data, pysam.AlignmentHeader.from_dict(dict()))
+        read = pysam.AlignedSegment.fromstring(
+            raw_data, pysam.AlignmentHeader.from_dict(dict())
+        )
 
         # Process and place our data on the output queue:
         out_queue.put(_get_segments(read))
 
 
-def _sub_process_write_fn(out_queue, out_bam_header, out_bam_file_name, pbar, do_simple_splitting, keep_delimiters):
+def _sub_process_write_fn(
+    out_queue,
+    out_bam_header,
+    out_bam_file_name,
+    pbar,
+    do_simple_splitting,
+    keep_delimiters,
+    res,
+):
     """Thread / process fn to write out all our data."""
-
-    num_reads_segmented = 0
-    num_segments = 0
 
     # Create our delimiter sequences for simple splitting if we have to:
     delimiters = _create_simple_delimiters() if do_simple_splitting else None
@@ -175,7 +203,7 @@ def _sub_process_write_fn(out_queue, out_bam_header, out_bam_file_name, pbar, do
         logger.debug(f"Delimiter sequences for simple delimiters: %s", delimiters)
 
     with pysam.AlignmentFile(
-            out_bam_file_name, "wb", header=out_bam_header
+        out_bam_file_name, "wb", header=out_bam_header
     ) as out_bam_file:
 
         while True:
@@ -198,18 +226,18 @@ def _sub_process_write_fn(out_queue, out_bam_header, out_bam_file_name, pbar, do
             )
 
             # Write out our segmented reads:
-            num_segments += _write_segmented_read(
-                read, segments, do_simple_splitting, keep_delimiters, delimiters, out_bam_file
+            res["num_segments"] += _write_segmented_read(
+                read,
+                segments,
+                do_simple_splitting,
+                keep_delimiters,
+                delimiters,
+                out_bam_file,
             )
 
             # Increment our counters:
-            num_reads_segmented += 1
+            res["num_reads_segmented"] += 1
             pbar.update(1)
-
-    logger.info(
-        f"annmas {mod_name}: segmented {num_reads_segmented} reads with {num_segments} total segments."
-    )
-    return
 
 
 def _create_simple_delimiters(num_seqs_from_each_array_element=1):
@@ -231,14 +259,16 @@ def _create_simple_delimiters(num_seqs_from_each_array_element=1):
     # that we expect to see them in the overall library:
     for i in range(1, len(array_element_structure)):
         delimiters.append(
-            tuple(array_element_structure[i - 1][-num_seqs_from_each_array_element:]) +
-            tuple(array_element_structure[i][0:num_seqs_from_each_array_element])
+            tuple(array_element_structure[i - 1][-num_seqs_from_each_array_element:])
+            + tuple(array_element_structure[i][0:num_seqs_from_each_array_element])
         )
 
     return delimiters
 
 
-def _write_segmented_read(read, segments, do_simple_splitting, keep_delimiters, delimiters, bam_out):
+def _write_segmented_read(
+    read, segments, do_simple_splitting, keep_delimiters, delimiters, bam_out
+):
     """Split and write out the segments of each read to the given bam output file.
 
     NOTE: Assumes that all given data are in the forward direction.
@@ -334,7 +364,9 @@ def _write_segmented_read(read, segments, do_simple_splitting, keep_delimiters, 
                 prev_delim_name,
             )
 
-            cur_read_base_index = end_seg_tuple[0].start if keep_delimiters else end_seg_tuple[1].end + 1
+            cur_read_base_index = (
+                end_seg_tuple[0].start if keep_delimiters else end_seg_tuple[1].end + 1
+            )
             prev_delim_name = delim_name
 
         # Now we have to write out the last segment:
@@ -348,7 +380,15 @@ def _write_segmented_read(read, segments, do_simple_splitting, keep_delimiters, 
         delim_name = "END"
 
         _write_split_array_element(
-            bam_out, start_coord, end_coord, seg_start_coord, seg_end_coord, read, segments, delim_name, prev_delim_name
+            bam_out,
+            start_coord,
+            end_coord,
+            seg_start_coord,
+            seg_end_coord,
+            read,
+            segments,
+            delim_name,
+            prev_delim_name,
         )
 
         return len(seg_delimiters)
@@ -457,7 +497,15 @@ def _transform_to_rc_coords(start, end, read_length):
 
 
 def _write_split_array_element(
-    bam_out, start_coord, end_coord, seg_start_coord, seg_end_coord, read, segments, delim_name, prev_delim_name
+    bam_out,
+    start_coord,
+    end_coord,
+    seg_start_coord,
+    seg_end_coord,
+    read,
+    segments,
+    delim_name,
+    prev_delim_name,
 ):
     """Write out an individual array element that has been split out according to the given coordinates."""
     a = pysam.AlignedSegment()
@@ -466,7 +514,7 @@ def _write_split_array_element(
     )
     # Add one to end_coord because coordinates are inclusive:
     a.query_sequence = f"{read.query_sequence[start_coord:end_coord+1]}"
-    a.query_qualities = read.query_alignment_qualities[start_coord:end_coord+1]
+    a.query_qualities = read.query_alignment_qualities[start_coord : end_coord + 1]
     a.tags = read.get_tags()
     a.flag = 4  # unmapped flag
     a.mapping_quality = 255
@@ -474,7 +522,13 @@ def _write_split_array_element(
     # Set our segments tag to only include the segments in this read:
     a.set_tag(
         SEGMENTS_TAG,
-        ",".join([s.to_tag() for s in segments if seg_start_coord <= s.start <= seg_end_coord]),
+        ",".join(
+            [
+                s.to_tag()
+                for s in segments
+                if seg_start_coord <= s.start <= seg_end_coord
+            ]
+        ),
     )
 
     bam_out.write(a)
@@ -482,4 +536,6 @@ def _write_split_array_element(
 
 def _get_segments(read):
     """Get the segments corresponding to a particular read by reading the segments tag information."""
-    return read.to_string(), [SegmentInfo.from_tag(s) for s in read.get_tag(SEGMENTS_TAG).split("|")]
+    return read.to_string(), [
+        SegmentInfo.from_tag(s) for s in read.get_tag(SEGMENTS_TAG).split("|")
+    ]

--- a/src/annmas/train/command.py
+++ b/src/annmas/train/command.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import click
 import click_log
@@ -9,25 +10,56 @@ import concurrent.futures
 
 from ..utils.model import *
 
-logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr)
+logger = logging.getLogger("train")
 click_log.basic_config(logger)
 
 
 @click.command(name="train")
 @click_log.simple_verbosity_option(logger)
-@click.option("-n", "--num-training-samples", type=int, default=10, show_default=True,
-              help="number of training samples to use")
-@click.option("-i", "--max-training-iterations", type=int, default=5, show_default=True,
-              help="number of training iterations to use")
-@click.option("-t", "--threads", type=int, default=1, show_default=True, help="number of threads to use (0 for all)")
-@click.option("-o", "--output-yaml", required=True, type=click.Path(exists=False), help="trained model")
-@click.argument('training-bam', type=click.Path(exists=True))
-def main(num_training_samples, max_training_iterations, threads, output_yaml, training_bam):
-    """Train transition and emission probabilities of model on real data"""
-    logger.info(f"annmas: train started")
+@click.option(
+    "-n",
+    "--num-training-samples",
+    type=int,
+    default=10,
+    show_default=True,
+    help="number of training samples to use",
+)
+@click.option(
+    "-i",
+    "--max-training-iterations",
+    type=int,
+    default=5,
+    show_default=True,
+    help="number of training iterations to use",
+)
+@click.option(
+    "-t",
+    "--threads",
+    type=int,
+    default=1,
+    show_default=True,
+    help="number of threads to use (0 for all)",
+)
+@click.option(
+    "-o",
+    "--output-yaml",
+    required=True,
+    type=click.Path(exists=False),
+    help="trained model",
+)
+@click.argument("training-bam", type=click.Path(exists=True))
+def main(
+    num_training_samples, max_training_iterations, threads, output_yaml, training_bam
+):
+    """Train transition and emission probabilities on real data."""
+
+    t_start = time.time()
+
+    logger.info("Invoked via: annmas %s", " ".join(sys.argv[1:]))
 
     threads = mp.cpu_count() if threads <= 0 or threads > mp.cpu_count() else threads
-    logger.info("Running with %d thread(s)", threads)
+    logger.info(f"Running with {threads} worker subprocess(es)")
 
     m = build_default_model()
     training_seqs = load_training_seqs(m, num_training_samples, threads, training_bam)
@@ -35,33 +67,42 @@ def main(num_training_samples, max_training_iterations, threads, output_yaml, tr
     logger.info("Loaded %d training sequences", len(training_seqs))
 
     logger.info("Starting training...", len(training_seqs))
-    improvement, history = m.fit(sequences=training_seqs,
-                                 max_iterations=max_training_iterations,
-                                 stop_threshold=1e-1,
-                                 return_history=True,
-                                 verbose=True,
-                                 n_jobs=threads)
+    improvement, history = m.fit(
+        sequences=training_seqs,
+        max_iterations=max_training_iterations,
+        stop_threshold=1e-1,
+        return_history=True,
+        verbose=True,
+        n_jobs=threads,
+    )
 
     with open(output_yaml, "w") as model_file:
         print(improvement.to_yaml(), file=model_file)
 
-    logger.info("annmas: train finished")
+    logger.info(f"Done. Elapsed time: %2.2fs.", time.time() - t_start)
 
 
 def load_training_seqs(m, num_training_samples, threads, training_bam):
     training_seqs = []
     raw_reads = []
     pysam.set_verbosity(0)  # silence message about the .bai file not being found
-    with pysam.AlignmentFile(training_bam, "rb", check_sq=False, require_index=False) as bam_file:
+    with pysam.AlignmentFile(
+        training_bam, "rb", check_sq=False, require_index=False
+    ) as bam_file:
         for r in bam_file:
             raw_reads.append(r)
 
             if len(raw_reads) > num_training_samples:
                 break
-    with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor, \
-            tqdm.tqdm(desc="Progress", unit=" reads", colour="green", file=sys.stdout) as pbar:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=threads
+    ) as executor, tqdm.tqdm(
+        desc="Progress", unit=" reads", colour="green", file=sys.stdout
+    ) as pbar:
 
-        future_to_segmented_read = {executor.submit(select_read, r, m): r for r in raw_reads}
+        future_to_segmented_read = {
+            executor.submit(select_read, r, m): r for r in raw_reads
+        }
 
         for future in concurrent.futures.as_completed(future_to_segmented_read):
             read = future_to_segmented_read[future]
@@ -69,7 +110,7 @@ def load_training_seqs(m, num_training_samples, threads, training_bam):
                 logp, seq = future.result()
                 training_seqs.append(list(seq))
             except Exception as ex:
-                logger.error('%r generated an exception: %s', read, ex)
+                logger.error("%r generated an exception: %s", read, ex)
 
             pbar.update(1)
     return training_seqs

--- a/src/annmas/train/command.py
+++ b/src/annmas/train/command.py
@@ -37,7 +37,7 @@ click_log.basic_config(logger)
     "-t",
     "--threads",
     type=int,
-    default=1,
+    default=mp.cpu_count() - 1,
     show_default=True,
     help="number of threads to use (0 for all)",
 )


### PR DESCRIPTION
This allow the following:

$ annmas annotate test_input.bam | annmas segment > test_output.bam

Related quality-of-life improvements:
 - logging information goes to stderr (to keep stdout clear for data pipes)
 - include the submodule name in the logging prefix
 - made logging output, elapsed time, and other misc. stuff a bit more consistent across tools
 - provide the command invocation as the first logging statement
 - set the default number of threads to be 1 (which might be friendlier to users on multi-user systems)