### PR TITLE
Improve inspect command to work with segmented BAMs

### DIFF
--- a/src/annmas/__main__.py
+++ b/src/annmas/__main__.py
@@ -19,7 +19,7 @@ from .meta import VERSION
 logger = logging.getLogger("version")
 click_log.basic_config(logger)
 logger.handlers[0].formatter = logging.Formatter(
-    "[%(levelname)s %(asctime)s %(name)s] %(message)s", "%Y-%m-%d %H:%M:%S"
+    "[%(levelname)s %(asctime)s %(name)8s] %(message)s", "%Y-%m-%d %H:%M:%S"
 )
 
 

--- a/src/annmas/annotate/command.py
+++ b/src/annmas/annotate/command.py
@@ -141,7 +141,7 @@ def main(model, threads, output_bam, input_bam):
         # Start output worker:
         res = manager.dict({"num_reads_annotated": 0, "num_sections": 0})
         output_worker = mp.Process(
-            target=_write_thread_fn, args=(results, out_header, output_bam, input_bam == "-", res)
+            target=_write_thread_fn, args=(results, out_header, output_bam, not sys.stdin.isatty(), res)
         )
         output_worker.start()
 
@@ -173,7 +173,7 @@ def main(model, threads, output_bam, input_bam):
         f"Annotated {res['num_reads_annotated']} reads with {res['num_sections']} total sections."
     )
     et = time.time()
-    logger.info(f"Done. Elapsed time: {et - t_start:2.2f}s.  "
+    logger.info(f"Done. Elapsed time: {et - t_start:2.2f}s. "
                 f"Overall processing rate: {res['num_reads_annotated']/(et - t_start):2.2f} reads/s.")
 
 

--- a/src/annmas/annotate/command.py
+++ b/src/annmas/annotate/command.py
@@ -4,7 +4,6 @@ import itertools
 import re
 import time
 import collections
-import os
 
 from inspect import getframeinfo, currentframe, getdoc
 
@@ -78,7 +77,7 @@ class SegmentInfo(collections.namedtuple("SegmentInfo", ["name", "start", "end"]
     type=click.Path(exists=False),
     help="annotated bam output  [default: stdout]",
 )
-@click.argument("input-bam", type=click.Path(exists=True))
+@click.argument("input-bam", default="-" if not sys.stdin.isatty() else None, type=click.File("rb"))
 def main(model, threads, output_bam, input_bam):
     """Annotate reads in a BAM file with segments from the model."""
 

--- a/src/annmas/inspect/command.py
+++ b/src/annmas/inspect/command.py
@@ -145,9 +145,12 @@ def load_read_offsets(pbi_file, read_names):
         name_pieces = re.split("/", read_name)
 
         hole_number = int(name_pieces[1])
-        if "ccs" and len(name_pieces) > 3:
-            rr = re.split("_", name_pieces[3])
-            range_end = int(rr[1]) - int(rr[0]) + 1
+        if "ccs" in name_pieces:
+            if len(name_pieces) > 3:
+                rr = re.split("_", name_pieces[3])
+                range_end = int(rr[1]) - int(rr[0]) + 1
+            else:
+                range_end = -1
         else:
             range_end = re.split("_", name_pieces[2])[1]
 
@@ -157,11 +160,14 @@ def load_read_offsets(pbi_file, read_names):
         idx_contents = fmt.parse_stream(f)
 
         for j in range(0, idx_contents.n_reads):
-            key = f"{idx_contents.holeNumber[j]}_{idx_contents.qEnd[j]}"
+            key1 = f"{idx_contents.holeNumber[j]}_{idx_contents.qEnd[j]}"
+            key2 = f"{idx_contents.holeNumber[j]}_-1"
 
             # Save virtual file offsets for the selected reads only
-            if key in file_offsets_hash:
-                file_offsets_hash[key]["offset"] = idx_contents.fileOffset[j]
+            if key1 in file_offsets_hash:
+                file_offsets_hash[key1]["offset"] = idx_contents.fileOffset[j]
+            elif key2 in file_offsets_hash:
+                file_offsets_hash[key2]["offset"] = idx_contents.fileOffset[j]
 
     return file_offsets_hash
 

--- a/src/annmas/segment/command.py
+++ b/src/annmas/segment/command.py
@@ -61,7 +61,7 @@ click_log.basic_config(logger)
     help="If True, will keep the delimiter sequences in the resulting reads.  Otherwise the delimiter sequence "
     "information will be removed from the resulting reads (the annotations for the delimiters will be preserved).",
 )
-@click.argument("input-bam", default="-", type=click.Path())
+@click.argument("input-bam", default="-" if not sys.stdin.isatty() else None, type=click.File("rb"))
 def main(threads, output_bam, do_simple_splitting, keep_delimiters, input_bam):
     """Segment pre-annotated reads from an input BAM file."""
 
@@ -101,7 +101,7 @@ def main(threads, output_bam, do_simple_splitting, keep_delimiters, input_bam):
         colour="green",
         file=sys.stderr,
         leave=False,
-        disable=input_bam == "-",
+        disable=not sys.stdin.isatty(),
     ) as pbar:
 
         # Get our header from the input bam file:
@@ -510,7 +510,7 @@ def _write_split_array_element(
     """Write out an individual array element that has been split out according to the given coordinates."""
     a = pysam.AlignedSegment()
     a.query_name = (
-        f"{read.query_name}_{start_coord}-{end_coord}_{prev_delim_name}-{delim_name}"
+        f"{read.query_name}/{start_coord}_{end_coord}/{prev_delim_name}-{delim_name}"
     )
     # Add one to end_coord because coordinates are inclusive:
     a.query_sequence = f"{read.query_sequence[start_coord:end_coord+1]}"


### PR DESCRIPTION
Inspect command now works with segmented BAMs.

Other changes:
- Replaced some underscores in the segmented read name with slashes. This plays a bit nicer with PacBio's .pbi index file format, and makes stuff slightly easier to parse in the inspect command.
- Improved some log formatting by making the log line prefix fixed-width.
- Fixed an issue where a command that takes data from stdin but is run with no arguments waits forever for input that's not coming, rather than the desired behavior of showing the help text.