### PR TITLE
Updates to splitting to fix delimiter / coordinate mismatch.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "\n"
     ),
     tests_require=["coverage", "pytest"],
-    python_requires=">=3.6",
+    python_requires=">=3.6, <=3.7.9",
     packages=find_packages("src"),
     package_dir={"": "src"},
     classifiers=[

--- a/src/annmas/utils/model.py
+++ b/src/annmas/utils/model.py
@@ -29,9 +29,8 @@ from pomegranate.callbacks import History, ModelCheckpoint
 # )
 
 array_element_structure = (
-    # The first element doesn't actually have the "A" adapter in this version of the library.
-    # ("A", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
-    ("10x_Adapter", "random", "Poly_A", "3p_Adapter"),
+    # NOTE: the first element doesn't currently have the "A" adapter in this version of the library.
+    ("A", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
     ("B", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
     ("C", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
     ("D", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
@@ -45,9 +44,8 @@ array_element_structure = (
     ("L", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
     ("M", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
     ("N", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
-    # The last element doesn't actually have the "P" adapter in this version of the library:
-    # ("O", "10x_Adapter", "random", "Poly_A", "3p_Adapter", "P"),
-    ("O", "10x_Adapter", "random", "Poly_A", "3p_Adapter"),
+    # The last element doesn't currently have the "P" adapter in this version of the library:
+    ("O", "10x_Adapter", "random", "Poly_A", "3p_Adapter", "P")
 )
 
 adapters = {


### PR DESCRIPTION
- Removed the `-k` flag.
- Updated splitting to keep appropriate delimiter sequences for each
array element.
- Updated bounded region (strict) splitting to account for the fact
that the current library prep removes the A and P adapters.  Now this
strict mode works for our dataset.

Fixes #16 #17 #19 