### PR TITLE
Fixed inspect model score for reads that have been annotated already.

### DIFF
--- a/src/longbow/inspect/command.py
+++ b/src/longbow/inspect/command.py
@@ -237,6 +237,9 @@ def annotate_read(read, m):
             qLen = int(qEnd) - int(qStart) + 1
 
             fppath.extend([state] * qLen)
+
+        # Set our logp from the bam file:
+        flogp = read.get_tag(bam_utils.READ_MODEL_SCORE_TAG)
     else:
         for seq in [read.query_sequence, reverse_complement(read.query_sequence)]:
             logp, ppath = m.annotate(seq)


### PR DESCRIPTION
The inspect command had a bug where it would not properly display the model score for reads that had already been annotated.  This PR fixes this issue.